### PR TITLE
Exclude unchanged items and provide exception detail if available

### DIFF
--- a/Source/BitDiffer.Common/BitDiffer.Common.csproj
+++ b/Source/BitDiffer.Common/BitDiffer.Common.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Detail\TraitDetail.cs" />
     <Compile Include="Detail\TypeDetail.cs" />
     <Compile Include="Exceptions\ArgumentParserException.cs" />
+    <Compile Include="Exceptions\ExceptionExtension.cs" />
     <Compile Include="Exceptions\WeakerMatchException.cs" />
     <Compile Include="Interfaces\IHandleProgress.cs" />
     <Compile Include="Interfaces\ICanNavigate.cs" />

--- a/Source/BitDiffer.Common/Exceptions/ExceptionExtension.cs
+++ b/Source/BitDiffer.Common/Exceptions/ExceptionExtension.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace BitDiffer.Common.Exceptions
+{
+    public static class ExceptionExtension
+    {
+        public static string GetNestedExceptionMessage(this Exception ex)
+        {
+            var sb = new StringBuilder();
+
+            while (ex != null)
+            {
+                if (sb.Length > 0)
+                {
+                    sb.Append(" -> ");
+                }
+
+                sb.Append(ex.Message);
+
+                if (ex is System.Reflection.ReflectionTypeLoadException)
+                {
+                    var typeLoadException = ex as ReflectionTypeLoadException;
+                    var loaderExceptions = typeLoadException.LoaderExceptions;
+                    foreach (Exception e in typeLoadException.LoaderExceptions)
+                    {
+                        
+                        var exFileNotFound = e as FileNotFoundException;
+                        if (exFileNotFound != null)
+                        {
+                            sb.Append(string.Format("\nFile:{0} FusionLog:{1} Message:{2}",
+                                exFileNotFound.FileName, exFileNotFound.FusionLog, exFileNotFound.Message));
+                        }
+                        else
+                        {
+                            sb.Append("\n" + e.Message);
+                        }
+                    }
+                }
+                else if (ex is FileNotFoundException)
+                {
+                    var exFileNotFound = ex as FileNotFoundException;
+                    sb.Append(string.Format("\nFile:{0} FusionLog:{1} Message:{2}",
+                        exFileNotFound.FileName, exFileNotFound.FusionLog, exFileNotFound.Message));
+                }
+
+                ex = ex.InnerException;
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/Source/BitDiffer.Core/AssemblyComparer.cs
+++ b/Source/BitDiffer.Core/AssemblyComparer.cs
@@ -6,7 +6,7 @@ using System.Runtime.Remoting.Messaging;
 using System.Text;
 using System.IO;
 using System.Threading;
-
+using BitDiffer.Common.Exceptions;
 using BitDiffer.Common.Model;
 using BitDiffer.Common.Utility;
 using BitDiffer.Common.Misc;
@@ -155,7 +155,7 @@ namespace BitDiffer.Core
 
             if (filter.ChangedItemsOnly)
             {
-                var removeList = ac.Groups.ToList().Where(g => g.Change == ChangeType.None);
+                var removeList = ac.Groups.ToList().Where(g => g.Change == ChangeType.None && !g.HasErrors);
                 removeList.ToList().ForEach(i => ac.Groups.Remove(i));
             }
 
@@ -266,40 +266,11 @@ namespace BitDiffer.Core
             catch (Exception ex)
             {
                 Log.Error("Unable to load assembly : {0}", act.FileName);
-                var sb = new StringBuilder();
-
-                while (ex != null)
-                {
-                    var msg = ex.Message;
-
-                    if (ex is System.Reflection.ReflectionTypeLoadException)
-                    {
-                        var typeLoadException = ex as ReflectionTypeLoadException;
-                        var loaderExceptions = typeLoadException.LoaderExceptions;
-                        foreach (Exception e in typeLoadException.LoaderExceptions)
-                        {
-                            msg += "\n" + e.Message;
-                            if (e is FileNotFoundException)
-                            {
-                                msg += ("\nFusion Log: " + (e as FileNotFoundException).FusionLog);
-                            }
-                        }
-                    }
-
-                    Log.Error(ex.Message);
-
-                    if (sb.Length > 0)
-                    {
-                        sb.Append(" -> ");
-                    }
-
-                    sb.Append(msg);
-                    ex = ex.InnerException;
-                }
-
                 act.Group.HasErrors = true;
-                act.Group.ErrorDetail = sb.ToString();
+                act.Group.ErrorDetail = ex.GetNestedExceptionMessage();
+                Log.Error(act.Group.ErrorDetail);
             }
         }
+
     }
 }

--- a/Source/BitDiffer.Extractor/AssemblyExtractor.cs
+++ b/Source/BitDiffer.Extractor/AssemblyExtractor.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Reflection;
 using System.IO;
 using System.Diagnostics;
-
+using BitDiffer.Common.Exceptions;
 using BitDiffer.Common.Model;
 using BitDiffer.Common.Utility;
 using BitDiffer.Common.Misc;
@@ -51,29 +51,10 @@ namespace BitDiffer.Extractor
 		        return new AssemblyDetail(assembly);
 		    }
             catch (Exception ex)
-		    {
-
-                var msg = new StringBuilder();
-                var typeLoadException = ex as System.Reflection.ReflectionTypeLoadException;
-
-                if (typeLoadException == null)
-		        {
-		            msg.Append(ex.Message);
-		        }
-                else
-		        {
-                    foreach (Exception e in typeLoadException.LoaderExceptions)
-		            {
-		                msg.Append("\n" + e.Message);
-		                if (e is FileNotFoundException)
-		                {
-		                    msg.Append("\nFusion Log: " + (e as FileNotFoundException).FusionLog);
-		                }
-		            }
-		        }
-
-		        Log.Error(msg.ToString());
-                throw new Exception( msg.ToString(), ex );
+            {
+                var errMessage = ex.GetNestedExceptionMessage();
+                Log.Error(errMessage);
+                throw new Exception(errMessage);
 		    }
 			finally
 			{


### PR DESCRIPTION
This update includes the following two updates: 
### 1. Exclude unchanged APIs

This update excludes APIs that have differences from the result set.  This change was necessary because `BitDiffer.Common.Misc.AssemblyComparison.Write*` methods dump all the API entities into respective XML or HTML file.  When the configuration setting "Changed Items Only" flag is on, then the resulting list will exclude unchanged APIs.  (UI setting Tools -> Comparison Set Configuration ->View Filter -> Changed Items Only).
### 2. Detailed exception

Updated exception to obtain extra details (i.e assembly paths) when possible.
