### PR TITLE
Get full path name in case of DOS 8.3 style assembly path

### DIFF
--- a/Source/BitDiffer.Core/AssemblyComparer.cs
+++ b/Source/BitDiffer.Core/AssemblyComparer.cs
@@ -169,7 +169,7 @@ namespace BitDiffer.Core
             {
                 if (Path.IsPathRooted(assemblyFiles[i]))
                 {
-                    assemblyFilesResolved[i] = assemblyFiles[i];
+                    assemblyFilesResolved[i] = Path.GetFullPath(assemblyFiles[i]);
                 }
                 else
                 {


### PR DESCRIPTION
When using custom SCM like Perforce, the diff utility can send DOS 8.3 style path. In those case, we need to normalize the path with this function.
This PR allows BitDiffer to be used from Perforce.